### PR TITLE
fix: wrong connection

### DIFF
--- a/schematics/BadgeMagic.kicad_sch
+++ b/schematics/BadgeMagic.kicad_sch
@@ -4226,12 +4226,6 @@
 		(uuid "4a66a898-2117-46bf-9279-16d460f2601f")
 	)
 	(junction
-		(at 146.05 121.92)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "4ac83f1a-6ec5-4338-8fb2-c72bab01dc09")
-	)
-	(junction
 		(at 102.87 44.45)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -14937,6 +14931,16 @@
 	)
 	(wire
 		(pts
+			(xy 146.05 114.3) (xy 146.05 115.57)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "901342a0-e0a8-436c-be25-9fa658a2a32a")
+	)
+	(wire
+		(pts
 			(xy 62.23 64.77) (xy 41.91 64.77)
 		)
 		(stroke
@@ -19777,16 +19781,6 @@
 	)
 	(wire
 		(pts
-			(xy 146.05 115.57) (xy 146.05 121.92)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "df9507c6-0079-4905-a217-d1c6e2e06f72")
-	)
-	(wire
-		(pts
 			(xy 219.71 41.91) (xy 240.03 41.91)
 		)
 		(stroke
@@ -22879,6 +22873,71 @@
 			(project "BadgeMagic"
 				(path "/340d1399-c919-4933-9577-a39de42237cb"
 					(reference "R1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:VCC")
+		(at 146.05 114.3 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "0bdf45e3-9377-4139-be6b-151387ab2b62")
+		(property "Reference" "#PWR025"
+			(at 146.05 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "VCC"
+			(at 146.05 110.236 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 146.05 114.3 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 146.05 114.3 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"VCC\""
+			(at 146.05 114.3 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "50b7eff9-9d4d-4a49-804a-0d0d27067af6")
+		)
+		(instances
+			(project "BadgeMagic"
+				(path "/340d1399-c919-4933-9577-a39de42237cb"
+					(reference "#PWR025")
 					(unit 1)
 				)
 			)


### PR DESCRIPTION
Turn out 2 buttons have different connections.

Before change:
![image](https://github.com/fossasia/badgemagic-hardware/assets/52123562/635e0168-52b6-4cab-b864-033903200551)

After change:
![image](https://github.com/fossasia/badgemagic-hardware/assets/52123562/043fc86d-8287-4210-8b94-bb51c958b7e1)
