### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The following software components are available:
 
 ## Buy Device
 
-* You can get a the board at the [FOSSASIA Shop](https://fossasia.com).
+* You can get the board at the [FOSSASIA Shop](https://fossasia.com).
 
 ## Platform
 


### PR DESCRIPTION
Hey everyone, I just saw you at the 38C3 and really liked your name tags! Really cool idea!
Sadly I was to late to get a `Pink` one, but thanks to this repository I don't need to be sad anymore :)
Then I found this small typo and here is my fix :)

There is also another thing: I think at the 38C3 you guys sold a version with USB-C and this hardware seems like it is the USB-C version?

But in the shop I can only find a Micro-USB version, so maybe it makes sense to clarify this in the README as well?

## Summary by Sourcery

Documentation:
- Fix typo: "a the board" to "the board".