### PR TITLE
Update README.md - Update to international WCH website and data

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ The following software components are available:
 
 ## Platform
 
-* Microcontroller Platform: [WCH CH582M](https://www.wch.cn/products/CH583.html)
+* Microcontroller Platform: [WCH QingKe RISC-V Bluetooth](https://wch-ic.com/products/productsCenter/mcuInterface?categoryId=63)
 * Toolchain: [MRS_Toolchain_Linux_x64_V1.91](http://www.mounriver.com/download)
 * Programming Tool: [wchisp](https://github.com/ch32-rs/wchisp)
 
 ## Parts list
 
-- [WCH CH582M](https://www.wch.cn/products/CH583.html) Microcontroller
+- [WCH CH582M(QFN48)](https://www.wch-ic.com/download/file?id=329) Microcontroller
 - [XC6206P332MR](https://www.torexsemi.com/file/xc6206/XC6206.pdf)
 - [LP4054](https://xor.co.za/post/2022-11-30-hacking-smartwatch/LP4054-Lowpowersemi.pdf) 
 - [DW03](https://wmsc.lcsc.com/wmsc/upload/file/pdf/v2/lcsc/2112031830_Shenzhen-Fuman-Elec-DW02R_C2927928.pdf)
@@ -45,6 +45,6 @@ The following software components are available:
 ## Hardware Specs
 
 - 11x44 LED Matrix display
-- BLE 5.0 
-- USB 2.0
+- BLE 5.3 
+- USB 1.1
 


### PR DESCRIPTION
WCH released their international website. https://www.wch-ic.com Update links and add more information about the hardware. Bluetooth of CH583/582 is capable of up to v5.3. CH585/584 is v5.4: https://wch-ic.com/products/productsCenter/mcuInterface?categoryId=63

USB from CH583/582 is USB v1.1. Not 2.0: https://www.wch-ic.com/download/file?id=329

USB 2.0 is a new feature that have been added in the newer CH585/584: https://www.wch-ic.com/download/file?id=402

## Summary by Sourcery

Update README to use WCH international website for QingKe microcontrollers and correct CH582/583 hardware specifications

Documentation:
- Switch microcontroller platform link to the international WCH QingKe RISC-V Bluetooth page
- Update CH582M part entry to QFN48 package with correct download link
- Correct hardware specs: set BLE to v5.3 and USB to v1.1 for CH582/583